### PR TITLE
Avoid duplicated header Vary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#3](https://github.com/boesing/zend-expressive-cors/pull/3) Avoid duplicated `Vary` header.
 
 ## 1.0.0 - 2019-11-19
 

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -72,7 +72,7 @@ final class CorsMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        return $response->withAddedHeader('Vary', $vary . ', Origin');
+        return $response->withHeader('Vary', $vary . ', Origin');
     }
 
     private function preflight(CorsMetadata $metadata) : ?ResponseInterface

--- a/test/Middleware/CorsMiddlewareTest.php
+++ b/test/Middleware/CorsMiddlewareTest.php
@@ -162,7 +162,7 @@ final class CorsMiddlewareTest extends TestCase
 
         $response
             ->expects($this->once())
-            ->method('withAddedHeader')
+            ->method('withHeader')
             ->with('Vary', 'Accept, Origin')
             ->willReturn($response);
 


### PR DESCRIPTION
Due to the usage of `MessageInterface::withAddedHeader`, the `Vary` header is duplicated with the `<old value>, Origin` extension.
This results in the following header structure returned from the server:

```
vary: foo, bar
vary: foo, bar, Origin
```